### PR TITLE
workflow: run for merge_group events as well

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,6 +1,9 @@
 # The name of the file should not be changed as it is used in Org Ruleset
 name: cla-check
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   cla-check:


### PR DESCRIPTION
For repos that use merge groups, this is required now.

Ref.: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group